### PR TITLE
remove python 3.8 syntax

### DIFF
--- a/graphlib/sorter.py
+++ b/graphlib/sorter.py
@@ -54,7 +54,8 @@ class TopologicalSorter(Generic[T]):
                 self.add(node, *predecessors)
 
     def _get_nodeinfo(self, node: T):
-        if (result := self._node2info.get(node)) is None:
+        result = self._node2info.get(node)
+        if result is None:
             self._node2info[node] = result = _NodeInfo(node)
         return result
 
@@ -169,7 +170,8 @@ class TopologicalSorter(Generic[T]):
         for node in nodes:
 
             # Check if we know about this node (it was added previously using add()
-            if (nodeinfo := n2i.get(node)) is None:
+            nodeinfo = n2i.get(node)
+            if nodeinfo is None:
                 raise ValueError(f"node {node!r} was not added using add()")
 
             # If the node has not being returned (marked as ready) previously, inform the user.


### PR DESCRIPTION
most notably remove :=